### PR TITLE
bugfix/VLWA-1577-display-previous-account-index-transactions-after-switch

### DIFF
--- a/menu-funcs.ls
+++ b/menu-funcs.ls
@@ -41,6 +41,8 @@ module.exports = (store, web3t)->
         console.log("menu-funcs refresh")
         store.forceReload = yes
         store.forceReloadTxs = yes
+        store.transactions.all = []
+        store.transactions.applied = []
         <- web3t.refresh
         store.forceReload = no
         store.forceReloadTxs = no


### PR DESCRIPTION
VLWA-1577 Added clearing transactions info on refresh wallet func;

<!-- Replace -->
[VLWA-1577](https://velasnetwork.atlassian.net/browse/VLWA-1577) – history is not updated after switch account or mainnet\testnet, need to click another token to update
<!-- Replace -->
