### PR TITLE
cleanup cached txs after failed query, update error message VLWA-1708

### DIFF
--- a/pages/history.ls
+++ b/pages/history.ls
@@ -1037,7 +1037,7 @@ module.exports = ({ store, web3t })->
                         .pug.err-message(style=err-message-style)
                             img.failed-txs-warning-icon.pug(src="#{icons.warning2}" style=icon-style)
                             .pug.failed-txs-warning-notification
-                                | An error occurred during getting transactions
+                                | Please update transactions’ history later, now it is not loading
                         button { store, classes: "retry-btn" text: \Retry , on-click: retry, icon: \retry }
             if length is 0 and wallet?txs-status is \loaded
                 text-style = 

--- a/transactions.ls
+++ b/transactions.ls
@@ -60,11 +60,10 @@ check-ptxs-in-background = (store, web3, network, token, [ptx, ...rest], cb)->
     check-ptxs-in-background store, web3, network, token, rest, cb
 export rebuild-history = (store, web3, wallet, cb)->
     { address, network, coin, private-key } = wallet
-    err, data <- get-transactions { address, network, coin.token, account: { address, private-key } }
+    err1, data <- get-transactions { address, network, coin.token, account: { address, private-key } }
     #console.log \rebuild-history, coin.token, err, data
-    return cb err if err?
     ids =
-        data |> map (.tx.to-upper-case!)
+        (data ? []) |> map (.tx.to-upper-case!)
     dummy = (err, data)->
         console.log err, data
     err, ptxs <- get-pending-txs { network, store, coin.token }
@@ -82,14 +81,14 @@ export rebuild-history = (store, web3, wallet, cb)->
     txs
         |> filter (.token is coin.token)
         |> each -> txs.splice txs.index-of(it), 1
-    data
+    data ? []
         |> each extend { address, coin, network }
         |> each txs~push
     ptxs
         |> map transform-ptx { address, coin, network }
         |> each extend { address, coin, network, pending: yes, checked: 0 }
         |> each txs~push
-    cb!
+    cb err1
 
 
 export load-all-transactions = (store, web3, cb)->


### PR DESCRIPTION


<!-- Replace -->
[VLWA-1708](https://velasnetwork.atlassian.net/browse/VLWA-1708) – after sending tx while history is unavailable, retry button is on top of tx list from cache
<!-- Replace -->
