### PR TITLE
update version for `1.2.57` to run autotests VLWA-1649

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "velas-wallet",
-  "version": "1.2.56",
+  "version": "1.2.57",
   "description": "",
   "main": "",
   "dependencies": {


### PR DESCRIPTION


<!-- Replace -->
[VLWA-1649](https://velasnetwork.atlassian.net/browse/VLWA-1649) – Make limits with caching (where available) for tx history for coins of  velas , ethereum, heco, bsc networks .
<!-- Replace -->
