### PR TITLE
feat/VLWA-1711-web-change-validators-backend-url-for-mainnet web3t

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,3 @@ Tested with `node --version` v11.10.1
 * ETC
 * USDT (+ USDT_ERC20)
 * and other less known
-


### PR DESCRIPTION
PR for autotests run for changing validators backend from https://github.com/velas/web3t/pull/37

<!-- Replace -->
[VLWA-1711](https://velasnetwork.atlassian.net/browse/VLWA-1711) – [web] change validators backend url for mainnet
<!-- Replace -->
