### PR TITLE
feature/VLWA-1897-add-link-to-snap-store-in-install-wallets-tab

### DIFF
--- a/e2e/src/tests/stable/links.test.ts
+++ b/e2e/src/tests/stable/links.test.ts
@@ -22,8 +22,10 @@ test.describe('Links', () => {
     for (let i = 0; i < donwloadLinks.length; i++) {
       const linkElement = donwloadLinks[i];
       const downloadLink = await linkElement.getAttribute('href');
-      const linkText = await linkElement.textContent();
-      assert.isTrue(downloadLink?.includes('https://github.com/velas/JsWalletDesktop'), `${linkText} doesn't lead to correct destination`);
+      if (!downloadLink?.includes('snapcraft')){
+        const linkText = await linkElement.textContent();
+        assert.isTrue(downloadLink?.includes('https://github.com/velas/JsWalletDesktop'), `${linkText} doesn't lead to correct destination`);        
+      }
     }
   });
 });

--- a/pages/downloadwallet.ls
+++ b/pages/downloadwallet.ls
@@ -117,6 +117,11 @@ build-version = (store, release)-->
         | last is 'exe' => "#{icons.windows}"
         | last is 'snap' => "#{icons.linux}"
     console.log "#{release.name}.md5"
+    download-container-style-for-two-btns = {display: "flex", align-items: "center",  justify-content: "space-evenly", }
+    download-container-style = 
+        | last is 'snap' => download-container-style-for-two-btns 
+        | _ => {}
+
     md5-file =
         store.releases
             |> map (it)->
@@ -130,8 +135,10 @@ build-version = (store, release)-->
         .pug.tag_name #{release.tag_name}
         .pug.source
             a.pug(href="#{source}" style=button-primary3-style target="_blank") Source Code
-        .pug.download
+        .pug.download(style=download-container-style)
             a.pug(href="#{release.browser_download_url}" style=button-primary1-style target="_blank") Install
+            if last is 'snap' 
+                    a.pug(href="https://snapcraft.io/velas-desktop-wallet" style=button-primary1-style target="_blank") Snapcraft
         .pug.source.link
             a.pug(href="#{md5-file?browser_download_url}" style=button-link target="_blank") MD5
 only-version = (item)->

--- a/pages/offlinewallets.ls
+++ b/pages/offlinewallets.ls
@@ -116,6 +116,11 @@ build-version = (store, release)-->
         | last is 'exe' => \ "#{icons.windows}"
         | last is 'snap' => \ "#{icons.linux}"
     console.log "#{release.name}.md5"
+    download-container-style-for-two-btns = {display: "flex", align-items: "center",  justify-content: "space-evenly", }
+    download-container-style = 
+        | last is 'snap' => download-container-style-for-two-btns 
+        | _ => {}
+    
     md5-file =
         store.releases |> find (-> it.name is "#{release.name}.md5")
     .pug.platform(style=resource)
@@ -124,8 +129,10 @@ build-version = (store, release)-->
         .pug.tag_name #{release.tag_name}
         .pug.source
             a.pug(href="#{source}" style=button-primary3-style target="_blank") Source Code
-        .pug.download
+        .pug.download(style=download-container-style)
             a.pug(href="#{release.browser_download_url}" style=button-primary1-style target="_blank") Download
+            if last is 'snap' 
+                    a.pug(href="https://snapcraft.io/velas-desktop-wallet" style=button-primary1-style target="_blank") Snapcraft
         .pug.source.link
             a.pug(href="#{md5-file?browser_download_url}" style=button-link target="_blank") MD5
 only-version = (item)->


### PR DESCRIPTION
added btn for desktop wallet snapcraft store

<!-- Replace -->
[VLWA-1897](https://velasnetwork.atlassian.net/browse/VLWA-1897) – add link to snap store in 'install wallets' tab
<!-- Replace -->
