### PR TITLE
fix/VLWA-1939-add-copy-button-for-staking-1-0-account-address

### DIFF
--- a/components/copy.ls
+++ b/components/copy.ls
@@ -5,7 +5,7 @@ require! {
     \../copied-inform.ls
     \../copy.ls
 }
-module.exports = ({ store, text })->
+module.exports = ({ store, text, elId })->
     style = get-primary-info store
     filter-icon=
         filter: style.app.filterIcon
@@ -15,5 +15,12 @@ module.exports = ({ store, text })->
         store.current.try-copy = text
     leave = ->
         store.current.try-copy = null
-    CopyToClipboard.pug(text="#{text}" on-copy=copied-inform(store) style=icon2 on-mouse-enter=enter on-mouse-leave=leave)
+    onCopy =  
+        | elId? => (event) ->
+                        # fixes the issue with no copied value after one click https://github.com/nkbt/react-copy-to-clipboard/issues/100#issuecomment-524057405
+                        el = document.getElementById elId
+                        el.click!
+                        copied-inform(store)(event)
+        | _ => copied-inform(store)
+    CopyToClipboard.pug(text="#{text}" id="#{elId}" on-copy=onCopy style=icon2 on-mouse-enter=enter on-mouse-leave=leave)
         copy store

--- a/pages/stake/account_details.ls
+++ b/pages/stake/account_details.ls
@@ -18,7 +18,6 @@ require! {
     \btoa
     \safe-buffer : { Buffer }
     \../../copied-inform.ls
-    \../../copy.ls
     \../../round5.ls
     \../../../web3t/addresses.js : { ethToVlx, vlxToEth }
     \../switch-account.ls
@@ -38,6 +37,8 @@ require! {
     \./rewards-stats.ls : RewardsStats
     \moment
     \../../components/popups/loader.ls
+    \../../components/copy.ls
+
 }
 .staking
     @import scheme
@@ -290,6 +291,8 @@ require! {
                     span
                         @media (max-width: 800px)
                             font-size: 14px
+                    .copy
+                        margin-left: 10px
                     .check
                         width: 15px
                         height: 15px
@@ -1019,6 +1022,8 @@ staking-content = (store, web3t)->
         font-weight: "bold"
         text-align: "center"
         max-width: "500px"
+    address-container-style = 
+        display: "flex"
     /* Render */    
     .pug.staking-content.delegate
         loader { loading: store.staking.splitting-staking-account, text: "Splitting in process" }
@@ -1038,9 +1043,10 @@ staking-content = (store, web3t)->
                     h3.pug #{lang.address}
                 .description.pug
                     .pug.chosen-account(title="#{store.staking.chosenAccount.address}")
-                        span.pug
+                        span.pug(style=address-container-style)
                             | #{store.staking.chosenAccount.address}
                             img.pug.check(src="#{icons.img-check}")
+                            copy { store, text: store.staking.chosenAccount.address }
             .pug.section
                 .title.pug
                     h3.pug ID

--- a/pages/stake/account_details.ls
+++ b/pages/stake/account_details.ls
@@ -1046,7 +1046,7 @@ staking-content = (store, web3t)->
                         span.pug(style=address-container-style)
                             | #{store.staking.chosenAccount.address}
                             img.pug.check(src="#{icons.img-check}")
-                            copy { store, text: store.staking.chosenAccount.address }
+                            copy { store, text: store.staking.chosenAccount.address, elId: "copy-address-chosenAccount" }
             .pug.section
                 .title.pug
                     h3.pug ID
@@ -1089,7 +1089,7 @@ staking-content = (store, web3t)->
                         | #{$validator}
                         if has-validator
                             img.pug.check(src="#{icons.img-check}")
-                        copy { store, text: validator }
+                        copy { store, text: validator, elId: "copy-address-validator" }
             .pug.section
                 .title.pug
                     h3.pug #{lang.creditsObserved}

--- a/pages/stake/account_details.ls
+++ b/pages/stake/account_details.ls
@@ -1085,10 +1085,11 @@ staking-content = (store, web3t)->
                 .title.pug
                     h3.pug #{lang.validator}
                 .description.pug
-                    span.pug.chosen-account
+                    span.pug.chosen-account(style=address-container-style)
                         | #{$validator}
                         if has-validator
                             img.pug.check(src="#{icons.img-check}")
+                        copy { store, text: validator }
             .pug.section
                 .title.pug
                     h3.pug #{lang.creditsObserved}


### PR DESCRIPTION
added `copy` right of address on staking 1.0 details page

<!-- Replace -->
[VLWA-1939](https://velasnetwork.atlassian.net/browse/VLWA-1939) – add copy button for staking 1.0 account address
<!-- Replace -->
